### PR TITLE
Resolve Address Not Saving issue for new users

### DIFF
--- a/src/scenes/Login/Login.tsx
+++ b/src/scenes/Login/Login.tsx
@@ -34,7 +34,7 @@ const Login: FC = () => {
       setIsLoggedIn(true);
       const [address, user] = extractAddress(res);
       setUser({ ...user, address });
-      if (res.ewUser) {
+      if (res.newUser) {
         setIsNewUser(true);
       }
       navigate("/");

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -36,13 +36,10 @@ export const updateUserinDB = async (
     method: "PUT",
     body: JSON.stringify(user),
   });
-  const addressRes = await api(`/address/${id}`, {
-    method: isNewUser? 'POST': 'PUT',
+  await api(`/address/${id}`, {
+    method: isNewUser ? "POST" : "PUT",
     body: JSON.stringify(user.address),
   });
-  console.log(res);
-  console.log(addressRes);
   const parsed = await res.json();
-  console.log(parsed);
   return parsed;
 };


### PR DESCRIPTION
Small typo lead to all users being treated as existing users, leading to incorrect API call when saving address for the first time

also, some small clean up.